### PR TITLE
Simple prompt : emergency fix to the incompatibility introduced by IPython 7 in 9.2.beta8

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,17 +47,45 @@
   1. See http://melpa.org/#/getting-started if you do not have a
      configuration for MELPA.
 
-  1. Install =sage-shell-mode= by
+  2. Install =sage-shell-mode= by
      - =M-x package-refresh-contents=
      - =M-x package-install RET sage-shell-mode=.
 
-  1. If you have Sage 7.3 or earlier, then add the following to your Emacs init file (=~/.emacs.d/init.el=):
+     (Alternatively, you can use [[https://github.com/jwiegley/use-package][=use-package=]] (available from MELPA) for installation and setup).
 
-     #+BEGIN_SRC elisp
-      (setq sage-shell:use-prompt-toolkit nil)
-     #+END_SRC
+  # 3. If you have Sage 7.3 or earlier, then add the following to your Emacs init file (=~/.emacs.d/init.el=):
 
-  1. You can now run Sage inside Emacs by =M-x sage-shell:run-sage=, if Emacs
+  #    #+BEGIN_SRC elisp
+  #     (setq sage-shell:use-prompt-toolkit nil)
+  #    #+END_SRC
+
+  3. Configuration.
+
+     Sage internally uses ~IPython~ to manage user interaction at the console, ~Jupyter~ cell or, in our case, ~emacs~ buffer. Due to IPython evolution (governed /upstream/ Sage), this interaction has to be managed differently by =sage-shell-mode= according to the ~Ipython~ version available, itself depending on Sage's version. This configuration is governed by two customizable variables :
+
+       * =sage-shell:use-prompt-toolkit=, which must be =t= for Sage versions >= 7.4.beta0 and < 9.2.beta8, and =nil= otherwise ;
+
+       * =sage-shell:use-simple-prompt=, which must be =t= for Sage versions >= 9.2.beta9, and =nil= otherwise.
+
+       (Note : Sage 9.2.beta8 is a lost cause ; complain fiercely, then upgrade to something newer...).
+
+     The function =sage-shell:set-ipython-version= does this automatically, but takes a couple of seconds to execute at startup. Its use is controlled by the custom variable =sage-shell:set-ipython-version-on-startup= (=t= by default).
+
+     Similarly, =sage-shell:check-ipython-version= (controlled by the custom variable =sage-shell:check-ipython-version-on-startup=) checks that your options are acceptable to your IPython version, and will yell at you (in the =*Messages*= buffer) if this is not the case.
+
+      By default, both functions are enabled at startup. A (reckless) user of (say) Sage 9.2.beta10 could shave a couple seconds startup time by setting :
+
+      #+begin_src elisp
+	(custom-set-variables
+	 '(sage-shell:use-prompt-toolkit nil)
+	 '(sage-shell:use-simple-prompt t)
+	 '(sage-shell:set-ipython-version-on-startup nil)
+	 '(sage-shell:check-ipython-version-on-startup nil))
+      #+end_src
+
+      in its =init= file (or in the =:init= clause of its =sage-shell-mode= =use-package= call).
+
+  6. You can now run Sage inside Emacs by =M-x sage-shell:run-sage=, if Emacs
      can find the executable file of Sage.
 
      If Emacs cannot find the executable file, add the following line to your Emacs init file:

--- a/sage-shell-mode.el
+++ b/sage-shell-mode.el
@@ -192,14 +192,20 @@ This string will be inserted to the temporary file before evaluating code."
   :group 'sage-shell)
 
 
-(defcustom sage-shell:use-prompt-toolkit t
-  "Non `nil' means the Sage process uses the new prompt of IPython 5."
+(defcustom sage-shell:use-prompt-toolkit nil
+  "Non `nil' means the Sage process uses the new prompt of IPython 5 and 6. Must be disabled for Ipython >=7, which is incompatible"
   :type 'boolean
   :group 'sage-shell)
 ;; (make-variable-buffer-local 'sage-shell:use-prompt-toolkit)
 
-(defcustom sage-shell:check-ipython-version-on-startup nil
-  "Non `nil' means check if `sage-shell:use-prompt-toolkit' is correctly set when starting the Sage process.
+(defcustom sage-shell:use-simple-prompt t
+  "Non `nil' means the Sage process must be started with the `simple-prompt' option and use `readline' to interact with IPython >=7."
+  :type 'boolean
+  :group 'sage-shell)
+
+
+(defcustom sage-shell:check-ipython-version-on-startup t
+  "Non `nil' means check if `sage-shell:use-prompt-toolkit' and `sage-shell:simple-prompt' are correctly set when starting the Sage process.
 The checking is done asyncally."
   :type 'boolean
   :group 'sage-shell)
@@ -1262,8 +1268,12 @@ if [ $1 = .. ]; then shift; fi; exec \"$@\""
                (read-from-minibuffer "Run sage (like this): "
                                      "sage" nil nil 'sage-shell:run-history
                                      "sage") " "))))
-    (format "%s %s" (sage-shell:sage-executable)
-            (mapconcat 'identity (cdr lst) " "))))
+    (format
+     (if sage-shell:use-simple-prompt
+	 "%s --simple-prompt %s"
+       "%s %s")
+     (sage-shell:sage-executable)
+     (mapconcat 'identity (cdr lst) " "))))
 
 (cl-defun sage-shell:run (cmd new &key
                               (switch-function 'switch-to-buffer)
@@ -1336,7 +1346,7 @@ function asks which process is to be restarted."
   (deferred:$
     (deferred:process
       (sage-shell:sage-executable)
-      "-c" "import IPython; print IPython.version_info[0]")
+      "-c" "from __future__ import print_function ; import IPython; print(IPython.version_info[0])")
     (deferred:nextc it
       (lambda (x)
         (message (concat
@@ -1344,16 +1354,31 @@ function asks which process is to be restarted."
                   startup-msg))
         (let ((version (string-to-number (sage-shell:trim-right x)))
               (msg nil))
-          (cond ((and (< version 5) sage-shell:use-prompt-toolkit)
+          (cond ((and (< version 5)
+		      (or sage-shell:use-prompt-toolkit
+			  not sage-shell:use-simple-prompt))
                  (setq msg
                        (concat
-                        "You should set `sage-shell:use-prompt-toolkit' to nil.\n"
-                        "Set it to nil and restart the SageMath process.")))
-                ((and (>= version 5) (null sage-shell:use-prompt-toolkit))
+                        "You should set both `sage-shell:use-prompt-toolkit'\n"
+			"and `sage-shell:use-simple-prompt' to nil.\n"
+                        "Set them to nil and restart the SageMath process.")))
+                ((and (>= version 5)
+		      (< version 7)
+		      (or sage-shell:use-simple-prompt
+			  (null sage-shell:use-prompt-toolkit)))
                  (setq msg
                        (concat
-                        "You should set `sage-shell:use-prompt-toolkit' to t.\n"
-                        "Set it to t and restart the SageMath process."))))
+                        "You should set `sage-shell:use-prompt-toolkit' to t\n"
+			"and `sage-shell:use-simple-prompt' to nil.\n"
+                        "Set or `customize' them and restart the SageMath process.")))
+		((and (>= version 7)
+		      (or (null sage-shell:use-simple-prompt)
+			  sage-shell:use-prompt-toolkit))
+                 (setq msg
+                       (concat
+                        "You should set `sage-shell:use-prompt-toolkit' to nil\n"
+			"and `sage-shell:use-simple-prompt' to t.\n"
+                        "Set or `customize' them and restart the SageMath process."))))
           (when msg
             (display-message-or-buffer msg)))))))
 


### PR DESCRIPTION
This emergency fix reverts to `readline` and adds the `--simple-prompt` option to the Sage command line (optuon introduced in 9.2.beta9).

A better fix would be to manage Cursor Positioning Requests sent by IPython in the `emacs` buffer. I don't know how to do this (and a cursory `Google`ing lets me think that I a m not alone and that this is *no* an easy task).

This does the job, WorksForMe, and could be useful to some `emacs`-`org-mode` users...

HTH,