### PR TITLE
Fix typo in prompt when no Sage processes running.

### DIFF
--- a/sage-shell-mode.el
+++ b/sage-shell-mode.el
@@ -4383,7 +4383,7 @@ whose key is in KEYS."
          ;; if there are no processes
          ((null proc-alist)
           (when (and start-p
-                     (y-or-n-p (concat "Threre are no Sage processes. "
+                     (y-or-n-p (concat "There are no Sage processes. "
                                        "Start new process? ")))
             (let ((proc-buf
                    (sage-shell:run


### PR DESCRIPTION
Fix very minor 1 character typo.