### PR TITLE
Fix the sage-shell-view-mode

### DIFF
--- a/emacs_sage_shell_view.py
+++ b/emacs_sage_shell_view.py
@@ -24,6 +24,7 @@ based on the IPython shell version.
 
 from emacs_sage_shell import ip
 from sage.repl.rich_output.output_basic import OutputLatex
+from sage.repl.rich_output.output_browser import OutputHtml
 
 from sage.repl.rich_output.output_catalog import OutputImagePng
 from sage.repl.rich_output.preferences import DisplayPreferences
@@ -43,6 +44,9 @@ class BackendEmacs(BackendIPythonCommandline):
     def default_preferences(self):
         return DisplayPreferences(text=self.__text)
 
+    def supported_output(self):
+        return [OutputLatex , OutputPlainText , OutputHtml , OutputImagePng]
+
     def _repr_(self):
         return "Emacs babel"
 
@@ -52,7 +56,7 @@ class BackendEmacs(BackendIPythonCommandline):
             msg = "BEGIN_PNG:%s:END_PNG" % msg
             return ({u'text/plain': msg}, {})
 
-        elif isinstance(rich_output, OutputLatex):
+        elif isinstance(rich_output, OutputHtml):
             text = "BEGIN_TEXT:" + str(plain_text.text.get(), 'utf-8') + ":END_TEXTBEGIN_LATEX:" + \
                    str(rich_output.latex.get(), 'utf-8') + ":END_LATEX"
             return ({'text/plain': text}, {})


### PR DESCRIPTION
I think this should fix #61 

I haven't tested this. @EmmanuelCharpentier  can you try if you have time?

It would be better to change `supported_output` to add `OutputHtml` to the `supported_output` of the parent class. And even better to raise the issue in sage-repository so that `OutputHtml` is not required to use `OutputLatex`.