### PR TITLE
Re-enable typeset output in Emacs' *Sage* buffer.

### DIFF
--- a/emacs_sage_shell_view.py
+++ b/emacs_sage_shell_view.py
@@ -23,7 +23,8 @@ based on the IPython shell version.
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from emacs_sage_shell import ip
-from sage.repl.rich_output.output_basic import OutputLatex
+from sage.repl.rich_output.output_basic import OutputLatex, OutputPlainText
+from sage.repl.rich_output.output_browser import OutputHtml
 
 from sage.repl.rich_output.output_catalog import OutputImagePng
 from sage.repl.rich_output.preferences import DisplayPreferences
@@ -43,6 +44,9 @@ class BackendEmacs(BackendIPythonCommandline):
     def default_preferences(self):
         return DisplayPreferences(text=self.__text)
 
+    def supported_output(self):
+        return [OutputLatex , OutputPlainText , OutputHtml , OutputImagePng]
+    
     def _repr_(self):
         return "Emacs babel"
 
@@ -52,7 +56,7 @@ class BackendEmacs(BackendIPythonCommandline):
             msg = "BEGIN_PNG:%s:END_PNG" % msg
             return ({u'text/plain': msg}, {})
 
-        elif isinstance(rich_output, OutputLatex):
+        elif isinstance(rich_output, OutputHtml):
             text = "BEGIN_TEXT:" + str(plain_text.text.get(), 'utf-8') + ":END_TEXTBEGIN_LATEX:" + \
                    str(rich_output.latex.get(), 'utf-8') + ":END_LATEX"
             return ({'text/plain': text}, {})

--- a/sage-shell-view.el
+++ b/sage-shell-view.el
@@ -207,7 +207,10 @@ computes the resolution automatically."
    sage-shell-view-latex-documentclass
    sage-shell-view-latex-preamble
    sage-shell-view-latex-math-environment
-   math-expr
+   ;; math-expr
+   (replace-regexp-in-string
+    "^\$+" ""
+    (replace-regexp-in-string "\$+$" "" math-expr))
    sage-shell-view-latex-math-environment))
 
 (defun sage-shell-view-dir-name ()


### PR DESCRIPTION
This patch adapts sage-shell-mode to recent pmodification of Sages' rich output generation, and filters spurious math delimiters.